### PR TITLE
feat: added pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # REST API of NICE GADGETS
-
+[API-LINK](https://stalwart-dolphin-d2ae39.netlify.app/.netlify/functions/server/products)
 ## Endpoints:
 - ### `[API_SUBPATH]/products`
   Allowed methods: `[get]`
@@ -8,6 +8,7 @@
     - `?sort={alphabetically}` - get alphabetically sorted products by name
     - `?sort={cheapest}` - get sorted products by cheapest price
     - `?sort={expensive}` - get sorted products by the expensive price
+    - `page={number}&perPage={4|8|16|all}` - get data by page per page value
 
   Params 
     - `/:productId` -  get extensive info about the product by `productId`

--- a/src/controllers/products.ts
+++ b/src/controllers/products.ts
@@ -1,15 +1,20 @@
 import { Request, Response } from 'express';
 import * as productsServices from '../services/products';
 import { SortType } from '../types/SortType';
+import { PerPageType } from '../types/PerPageType';
 
 export const getAll = async (req: Request, res: Response) => {
   const sort = req.query.sort as SortType || SortType.Newest;
+  const perPage = req.query.perPage as PerPageType || PerPageType.All;
+  const page = Number(req.query.page) || 1;
 
-  const products = await productsServices.getAllByQuery(
+  const productsData = await productsServices.getAllByQuery(
     sort.toLowerCase() as SortType,
+    page,
+    perPage,
   );
 
-  res.send(products);
+  res.send(productsData);
 };
 
 export const getSingle = async (req: Request, res: Response) => {

--- a/src/services/products.ts
+++ b/src/services/products.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import { SortType } from '../types/SortType';
 import { Product } from '../types/Product';
+import { PerPageType } from '../types/PerPageType';
 
 const ALL_PHONES_PATH = 'src/data/phones.json';
 const EXTENSIVE_PHONES_PATH = 'src/data/phones/';
@@ -11,14 +12,19 @@ const read = async (path: string): Promise<Product[] | null> => {
   return JSON.parse(products);
 };
 
-export const getAllByQuery = async (sort: SortType) => {
-  const products = await read(ALL_PHONES_PATH);
+export const getAllByQuery = async (
+  sort: SortType,
+  page = 1,
+  perPage: PerPageType = PerPageType.All,
+) => {
+  let products = await read(ALL_PHONES_PATH);
+  const productsLength = products?.length;
 
   if (!products) {
     return null;
   }
 
-  return [...products].sort((prevProduct, currProduct) => {
+  products = [...products].sort((prevProduct, currProduct) => {
     switch (sort) {
       case SortType.Newest:
         return currProduct.year - prevProduct.year;
@@ -36,6 +42,22 @@ export const getAllByQuery = async (sort: SortType) => {
         return 0;
     }
   });
+
+  if (perPage !== PerPageType.All) {
+    const numberPerPage = +perPage;
+    const startIndex = (page - 1) * numberPerPage;
+    const possibleEndIndex = startIndex + numberPerPage;
+    const endIndex = possibleEndIndex > products.length
+      ? products.length
+      : possibleEndIndex;
+
+    products = products.slice(startIndex, endIndex);
+  }
+
+  return {
+    phones: products,
+    length: productsLength,
+  };
 };
 
 export const getSingleById = async (productId: string) => {

--- a/src/types/PerPageType.ts
+++ b/src/types/PerPageType.ts
@@ -1,0 +1,6 @@
+export enum PerPageType {
+  Four = 4,
+  Eight = 8,
+  Sixteen = 16,
+  All = 'all',
+}


### PR DESCRIPTION
# REST API of NICE GADGETS
[API-LINK](https://deploy-preview-4--stalwart-dolphin-d2ae39.netlify.app/.netlify/functions/server/products?page=1&perPage=4) - you can test it here
## Endpoints:
- ### `[API_SUBPATH]/products`
  Allowed methods: `[get]`
    - _without **query** params_ - get all products sorted by newest by default
    - `?sort={newest}` - get sorted products by date of release
    - `?sort={alphabetically}` - get alphabetically sorted products by name
    - `?sort={cheapest}` - get sorted products by cheapest price
    - `?sort={expensive}` - get sorted products by the expensive price
    - `?page={number}&perPage={4|8|16|all}` - get data by page per page value

  Params 
    - `/:productId` -  get extensive info about the product by `productId`